### PR TITLE
Add NuGet.Config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+  <disabledPackageSources />
+  <config>
+    <add key="repositoryPath" value=".\packages" />
+  </config>
+  <activePackageSource>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
Project expects packages to be at ./packages, but if your dev box isn't
configured to do this by default, build won't work. Having local
NuGet.Config will force packages to download that way.

Fixes #11